### PR TITLE
Renamed `ContextMerge` to `MergeContext`

### DIFF
--- a/crates/rust-releases-core/CHANGELOG.md
+++ b/crates/rust-releases-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Renamed `ContextMerge` to `MergeContext` for consistency with `MergeReleaseDate` amd `MergeToolchains`
+
 ## 0.33.0 - 2026-05-08
 
 ### Maintenance

--- a/crates/rust-releases-core/src/merge/builder.rs
+++ b/crates/rust-releases-core/src/merge/builder.rs
@@ -1,7 +1,7 @@
 use crate::merge::strategy::context::UnitContext;
 use crate::merge::strategy::release_date::PreferLeftDate;
 use crate::merge::strategy::toolchains::UnionToolchains;
-use crate::merge::{merge, ContextMerge, MergeReleaseDate, MergeToolchains};
+use crate::merge::{merge, MergeContext, MergeReleaseDate, MergeToolchains};
 use rust_release::RustRelease;
 use std::fmt::Debug;
 
@@ -16,9 +16,9 @@ where
 {
     left: RustRelease<V, CL>,
     right: RustRelease<V, CR>,
-    date_merge: D,
-    toolchains_merge: T,
-    context_merge: C,
+    date: D,
+    toolchains: T,
+    context: C,
 }
 
 impl<V: Debug> MergeBuilder<V, (), (), PreferLeftDate, UnionToolchains, UnitContext> {
@@ -26,9 +26,9 @@ impl<V: Debug> MergeBuilder<V, (), (), PreferLeftDate, UnionToolchains, UnitCont
         Self {
             left,
             right,
-            date_merge: PreferLeftDate,
-            toolchains_merge: UnionToolchains,
-            context_merge: UnitContext,
+            date: PreferLeftDate,
+            toolchains: UnionToolchains,
+            context: UnitContext,
         }
     }
 }
@@ -38,7 +38,7 @@ where
     V: Eq + Debug,
     D: MergeReleaseDate,
     T: MergeToolchains,
-    C: ContextMerge<CL, CR>,
+    C: MergeContext<CL, CR>,
 {
     pub fn date_merge<D2: MergeReleaseDate>(
         self,
@@ -47,35 +47,35 @@ where
         MergeBuilder {
             left: self.left,
             right: self.right,
-            date_merge,
-            toolchains_merge: self.toolchains_merge,
-            context_merge: self.context_merge,
+            date: date_merge,
+            toolchains: self.toolchains,
+            context: self.context,
         }
     }
 
     pub fn toolchains_merge<T2: MergeToolchains>(
         self,
-        toolchains_merge: T2,
+        toolchains: T2,
     ) -> MergeBuilder<V, CL, CR, D, T2, C> {
         MergeBuilder {
             left: self.left,
             right: self.right,
-            date_merge: self.date_merge,
-            toolchains_merge,
-            context_merge: self.context_merge,
+            date: self.date,
+            toolchains,
+            context: self.context,
         }
     }
 
-    pub fn context_merge<C2: ContextMerge<CL, CR>>(
+    pub fn context_merge<C2: MergeContext<CL, CR>>(
         self,
         context_merge: C2,
     ) -> MergeBuilder<V, CL, CR, D, T, C2> {
         MergeBuilder {
             left: self.left,
             right: self.right,
-            date_merge: self.date_merge,
-            toolchains_merge: self.toolchains_merge,
-            context_merge,
+            date: self.date,
+            toolchains: self.toolchains,
+            context: context_merge,
         }
     }
 
@@ -83,9 +83,9 @@ where
         merge(
             self.left,
             self.right,
-            &self.date_merge,
-            &self.toolchains_merge,
-            &self.context_merge,
+            &self.date,
+            &self.toolchains,
+            &self.context,
         )
     }
 }

--- a/crates/rust-releases-core/src/merge/from_fn.rs
+++ b/crates/rust-releases-core/src/merge/from_fn.rs
@@ -1,4 +1,4 @@
-use crate::merge::{ContextMerge, MergeReleaseDate, MergeToolchains};
+use crate::merge::{MergeContext, MergeReleaseDate, MergeToolchains};
 use rust_release::{date, toolchain};
 
 /// Wraps a closure into a merge trait implementation.
@@ -58,7 +58,7 @@ where
     }
 }
 
-impl<CL, CR, CO, F> ContextMerge<CL, CR> for FromFn<F>
+impl<CL, CR, CO, F> MergeContext<CL, CR> for FromFn<F>
 where
     F: Fn(CL, CR) -> CO,
 {
@@ -115,8 +115,8 @@ where
     FromFn(f)
 }
 
-/// Creates a [`ContextMerge`] strategy from a closure.
-pub fn context_fn<CL, CR, CO, F>(f: F) -> impl ContextMerge<CL, CR, Output = CO>
+/// Creates a [`MergeContext`] strategy from a closure.
+pub fn context_fn<CL, CR, CO, F>(f: F) -> impl MergeContext<CL, CR, Output = CO>
 where
     F: Fn(CL, CR) -> CO,
 {

--- a/crates/rust-releases-core/src/merge/mod.rs
+++ b/crates/rust-releases-core/src/merge/mod.rs
@@ -30,7 +30,7 @@ pub trait MergeToolchains {
 ///
 /// Separate from the field traits because it carries type parameters
 /// that vary per call site.
-pub trait ContextMerge<CL, CR> {
+pub trait MergeContext<CL, CR> {
     type Output;
 
     fn merge_context(&self, left: CL, right: CR) -> Self::Output;
@@ -55,7 +55,7 @@ where
     V: Eq + Debug,
     D: MergeReleaseDate,
     T: MergeToolchains,
-    C: ContextMerge<CL, CR>,
+    C: MergeContext<CL, CR>,
 {
     debug_assert_eq!(
         left.version, right.version,

--- a/crates/rust-releases-core/src/merge/strategy/context.rs
+++ b/crates/rust-releases-core/src/merge/strategy/context.rs
@@ -1,9 +1,9 @@
-use crate::merge::ContextMerge;
+use crate::merge::MergeContext;
 
 /// Trivial context merge for the unit type.
 pub struct UnitContext;
 
-impl ContextMerge<(), ()> for UnitContext {
+impl MergeContext<(), ()> for UnitContext {
     type Output = ();
 
     fn merge_context(&self, _left: (), _right: ()) {}


### PR DESCRIPTION
This is for consistency with `MergeReleaseDate` and `MergeToolchains`