### PR TITLE
Added convenience function `empty` to instantiate an empty instance

### DIFF
--- a/crates/rust-releases-core/CHANGELOG.md
+++ b/crates/rust-releases-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added convenience function `empty` to instantiate an empty `StableReleases`, `BetaReleases`, `NightlyReleases` instance with a context `C = ()`
+
 ### Changed
 
 - Renamed `ContextMerge` to `MergeContext` for consistency with `MergeReleaseDate` amd `MergeToolchains`

--- a/crates/rust-releases-core/src/releases/beta.rs
+++ b/crates/rust-releases-core/src/releases/beta.rs
@@ -38,6 +38,29 @@ impl<C> BetaReleases<C> {
 }
 
 impl BetaReleases<()> {
+    /// Create a new, but empty, instance.
+    ///
+    /// NB: This function is only available for `C = ()`. Instances which use a different type `C`
+    ///     can be created using `BetaReleases::<C>::default()`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use rust_releases_core::BetaReleases;
+    ///
+    /// let releases = BetaReleases::empty();
+    ///
+    /// assert!(releases.is_empty());
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// [`BetaReleases::default`]: create an empty collection, with any context type `C`.
+    /// [`BetaReleases::add`]: add releases to the collection.
+    pub fn empty() -> Self {
+        Self(impls::ReleasesImpl::default())
+    }
+
     /// Merge two collections using default strategies (prefer left date, union toolchains).
     ///
     /// Releases that exist in only one collection are included unchanged.

--- a/crates/rust-releases-core/src/releases/nightly.rs
+++ b/crates/rust-releases-core/src/releases/nightly.rs
@@ -38,6 +38,29 @@ impl<C> NightlyReleases<C> {
 }
 
 impl NightlyReleases<()> {
+    /// Create a new, but empty, instance.
+    ///
+    /// NB: This function is only available for `C = ()`. Instances which use a different type `C`
+    ///     can be created using `NightlyReleases::<C>::default()`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use rust_releases_core::NightlyReleases;
+    ///
+    /// let releases = NightlyReleases::empty();
+    ///
+    /// assert!(releases.is_empty());
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// [`NightlyReleases::default`]: create an empty collection, with any context type `C`.
+    /// [`NightlyReleases::add`]: add releases to the collection.
+    pub fn empty() -> Self {
+        Self(impls::ReleasesImpl::default())
+    }
+
     /// Merge two collections using default strategies (prefer left date, union toolchains).
     ///
     /// Releases that exist in only one collection are included unchanged.

--- a/crates/rust-releases-core/src/releases/stable.rs
+++ b/crates/rust-releases-core/src/releases/stable.rs
@@ -38,6 +38,29 @@ impl<C> StableReleases<C> {
 }
 
 impl StableReleases<()> {
+    /// Create a new, but empty, instance.
+    ///
+    /// NB: This function is only available for `C = ()`. Instances which use a different type `C`
+    ///     can be created using `StableReleases::<C>::default()`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use rust_releases_core::StableReleases;
+    ///
+    /// let releases = StableReleases::empty();
+    ///
+    /// assert!(releases.is_empty());
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// [`StableReleases::default`]: create an empty collection, with any context type `C`.
+    /// [`StableReleases::add`]: add releases to the collection.
+    pub fn empty() -> Self {
+        Self(impls::ReleasesImpl::default())
+    }
+
     /// Merge two collections using default strategies (prefer left date, union toolchains).
     ///
     /// Releases that exist in only one collection are included unchanged.
@@ -159,5 +182,11 @@ mod tests {
         assert!(versions.contains(&&Stable::new(1, 0, 0)));
         assert!(versions.contains(&&Stable::new(2, 0, 0)));
         assert!(versions.contains(&&Stable::new(3, 0, 0)));
+    }
+
+    #[test]
+    fn empty() {
+        let releases = StableReleases::empty();
+        assert!(releases.is_empty());
     }
 }


### PR DESCRIPTION
- Added convenience function `empty` to instantiate an empty `StableReleases`, `BetaReleases`, `NightlyReleases` instance with a context `C = ()`