### PR TITLE
Added `map`, `map_version`, `map_release_date`, `map_toolchains`, and `map_context`

### DIFF
--- a/crates/rust-releases-core/CHANGELOG.md
+++ b/crates/rust-releases-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Implement `FromIterator` for `StableReleases`, `BetaReleases` and `NightlyReleases`
 - Implement `IntoIterator` for `StableReleases`, `BetaReleases` and `NightlyReleases`
 - Implement `PartialEq` for `StableReleases`, `BetaReleases` and `NightlyReleases`
+- Added `map`, `map_version`, `map_release_date`, `map_toolchains`, and `map_context` to `StableReleases`
 
 ### Changed
 

--- a/crates/rust-releases-core/CHANGELOG.md
+++ b/crates/rust-releases-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Implement `FromIterator` for `StableReleases`, `BetaReleases` and `NightlyReleases`
 - Implement `IntoIterator` for `StableReleases`, `BetaReleases` and `NightlyReleases`
 - Implement `PartialEq` for `StableReleases`, `BetaReleases` and `NightlyReleases`
-- Added `map`, `map_version`, `map_release_date`, `map_toolchains`, and `map_context` to `StableReleases`
+- Added `map`, `map_ver sion`, `map_release_date`, `map_toolchains`, and `map_context` to `StableReleases`, , `BetaReleases` and `NightlyReleases`
 
 ### Changed
 

--- a/crates/rust-releases-core/src/releases/beta.rs
+++ b/crates/rust-releases-core/src/releases/beta.rs
@@ -1,6 +1,6 @@
 use crate::releases::impls;
 use crate::Beta;
-use rust_release::RustRelease;
+use rust_release::{date, toolchain, RustRelease};
 use std::iter::FromIterator;
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -25,6 +25,131 @@ impl<C> BetaReleases<C> {
     /// Iterate over the releases
     pub fn iter(&self) -> impl Iterator<Item = &RustRelease<Beta, C>> {
         self.0.iter()
+    }
+
+    /// Map the `release` and re-collect the result.
+    ///
+    /// # Warning: may result in unintended consequences
+    ///
+    /// Internally, versions are stored by `version` in a `BTreeSet`, so if you
+    /// map the version specifically, you might lose releases unexpectedly.
+    pub fn map<F>(self, f: F) -> BetaReleases<C>
+    where
+        F: FnMut(RustRelease<Beta, C>) -> RustRelease<Beta, C>,
+    {
+        let releases = self.into_iter().map(f).collect();
+
+        BetaReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `version` property of all releases in the set.
+    ///
+    /// # Warning: may result in unintended consequences
+    ///
+    /// Since the `version` field of a [`RustRelease`] is the only relevant property for
+    /// equivalence wrt `PartialEq`, `Eq`, `PartialOrd` and `Ord`, in set of `RustRelease` elements,
+    /// changing the `version` of multiple elements to the same version may have unintended
+    /// consequences.
+    ///
+    /// For example:
+    ///
+    /// ```
+    ///  # use rust_release::RustRelease;
+    ///  # use rust_releases_core::{Beta, BetaReleases};
+    ///
+    ///  let item0 = RustRelease::new(Beta::new(1, 2, 3, None), None, []);
+    ///  let item1 = RustRelease::new(Beta::new(2, 3, 4, None), None, []);
+    ///
+    ///  let mut original = BetaReleases::empty();
+    ///  original.add(item0.clone());
+    ///  original.add(item1.clone());
+    ///  assert_eq!(original.len(), 2);
+    ///
+    ///  // Eq. is determined by version
+    ///  let modified = original.map_version(|_| Beta::new(9, 9, 9, None));
+    ///  assert_eq!(modified.len(), 1);
+    /// ```
+    pub fn map_version<F>(self, mut f: F) -> BetaReleases<C>
+    where
+        F: FnMut(&RustRelease<Beta, C>) -> Beta,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let version = f(&r);
+                RustRelease {
+                    version,
+                    release_date: r.release_date,
+                    toolchains: r.toolchains,
+                    context: r.context,
+                }
+            })
+            .collect();
+
+        BetaReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `release_date` property of all releases in the set.
+    pub fn map_release_date<F>(self, mut f: F) -> BetaReleases<C>
+    where
+        F: FnMut(&RustRelease<Beta, C>) -> Option<date::Date>,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let release_date = f(&r);
+                RustRelease {
+                    version: r.version,
+                    release_date,
+                    toolchains: r.toolchains,
+                    context: r.context,
+                }
+            })
+            .collect();
+
+        BetaReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `toolchains` property of all releases in the set.
+    pub fn map_toolchains<F>(self, mut f: F) -> BetaReleases<C>
+    where
+        F: FnMut(&RustRelease<Beta, C>) -> Vec<toolchain::Toolchain>,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let toolchains = f(&r);
+                RustRelease {
+                    version: r.version,
+                    release_date: r.release_date,
+                    toolchains,
+                    context: r.context,
+                }
+            })
+            .collect();
+
+        BetaReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `context` property of all releases in the set, changing the context type from `C` to `C2`.
+    pub fn map_context<C2, F>(self, mut f: F) -> BetaReleases<C2>
+    where
+        F: FnMut(&RustRelease<Beta, C>) -> C2,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let context = f(&r);
+                RustRelease {
+                    version: r.version,
+                    release_date: r.release_date,
+                    toolchains: r.toolchains,
+                    context,
+                }
+            })
+            .collect();
+
+        BetaReleases(impls::ReleasesImpl::new(releases))
     }
 
     /// Merge two collections, applying `merge_fn` to releases that exist in both.
@@ -91,14 +216,7 @@ mod tests {
     use rust_release::toolchain::RustVersion;
 
     fn make_release(major: u64, minor: u64, patch: u64) -> RustRelease<Beta> {
-        RustRelease::new(
-            Beta {
-                version: RustVersion::new(major, minor, patch),
-                prerelease: None,
-            },
-            None,
-            [],
-        )
+        RustRelease::new(Beta::new(major, minor, patch, None), None, [])
     }
 
     #[test]
@@ -116,17 +234,23 @@ mod tests {
         assert_eq!(merged.len(), 3);
 
         let versions: Vec<_> = merged.iter().map(|r| &r.version).collect();
-        assert!(versions.contains(&&Beta {
-            version: RustVersion::new(1, 0, 0),
-            prerelease: None
-        }));
-        assert!(versions.contains(&&Beta {
-            version: RustVersion::new(2, 0, 0),
-            prerelease: None
-        }));
-        assert!(versions.contains(&&Beta {
-            version: RustVersion::new(3, 0, 0),
-            prerelease: None
-        }));
+        assert!(versions.contains(&&Beta::new(1, 0, 0, None)));
+        assert!(versions.contains(&&Beta::new(2, 0, 0, None)));
+        assert!(versions.contains(&&Beta::new(3, 0, 0, None)));
+    }
+
+    #[test]
+    fn map_version() {
+        let mut original = BetaReleases::empty();
+        original.add(make_release(1, 2, 3));
+        original.add(make_release(2, 3, 4));
+        assert_eq!(original.len(), 2);
+
+        // Eq. is determined by version
+        let modified = original.map_version(|_b| Beta::new(9, 9, 9, None));
+        assert_eq!(modified.len(), 1);
+
+        let out = modified.iter().next().unwrap();
+        assert_eq!(out.version().version, RustVersion::new(9, 9, 9));
     }
 }

--- a/crates/rust-releases-core/src/releases/mod.rs
+++ b/crates/rust-releases-core/src/releases/mod.rs
@@ -32,6 +32,11 @@ pub(in crate::releases) mod impls {
     where
         V: Ord,
     {
+        /// Create a new instance
+        pub fn new(releases: BTreeSet<RustRelease<V, C>>) -> Self {
+            Self { releases }
+        }
+
         /// Add a release to the collection
         pub fn add(&mut self, release: RustRelease<V, C>) {
             self.releases.insert(release);

--- a/crates/rust-releases-core/src/releases/nightly.rs
+++ b/crates/rust-releases-core/src/releases/nightly.rs
@@ -1,6 +1,6 @@
 use crate::releases::impls;
 use crate::Nightly;
-use rust_release::RustRelease;
+use rust_release::{date, toolchain, RustRelease};
 use std::iter::FromIterator;
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -25,6 +25,131 @@ impl<C> NightlyReleases<C> {
     /// Iterate over the releases
     pub fn iter(&self) -> impl Iterator<Item = &RustRelease<Nightly, C>> {
         self.0.iter()
+    }
+
+    /// Map the `release` and re-collect the result.
+    ///
+    /// # Warning: may result in unintended consequences
+    ///
+    /// Internally, versions are stored by `version` in a `BTreeSet`, so if you
+    /// map the version specifically, you might lose releases unexpectedly.
+    pub fn map<F>(self, f: F) -> NightlyReleases<C>
+    where
+        F: FnMut(RustRelease<Nightly, C>) -> RustRelease<Nightly, C>,
+    {
+        let releases = self.into_iter().map(f).collect();
+
+        NightlyReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `version` property of all releases in the set.
+    ///
+    /// # Warning: may result in unintended consequences
+    ///
+    /// Since the `version` field of a [`RustRelease`] is the only relevant property for
+    /// equivalence wrt `PartialEq`, `Eq`, `PartialOrd` and `Ord`, in set of `RustRelease` elements,
+    /// changing the `version` of multiple elements to the same version may have unintended
+    /// consequences.
+    ///
+    /// For example:
+    ///
+    /// ```
+    ///  # use rust_release::RustRelease;
+    ///  # use rust_releases_core::{Nightly, NightlyReleases};
+    ///
+    ///  let item0 = RustRelease::new(Nightly::new(2024, 1, 2), None, []);
+    ///  let item1 = RustRelease::new(Nightly::new(2024, 2, 3), None, []);
+    ///
+    ///  let mut original = NightlyReleases::empty();
+    ///  original.add(item0.clone());
+    ///  original.add(item1.clone());
+    ///  assert_eq!(original.len(), 2);
+    ///
+    ///  // Eq. is determined by version
+    ///  let modified = original.map_version(|_| Nightly::new(2024, 9, 9));
+    ///  assert_eq!(modified.len(), 1);
+    /// ```
+    pub fn map_version<F>(self, mut f: F) -> NightlyReleases<C>
+    where
+        F: FnMut(&RustRelease<Nightly, C>) -> Nightly,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let version = f(&r);
+                RustRelease {
+                    version,
+                    release_date: r.release_date,
+                    toolchains: r.toolchains,
+                    context: r.context,
+                }
+            })
+            .collect();
+
+        NightlyReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `release_date` property of all releases in the set.
+    pub fn map_release_date<F>(self, mut f: F) -> NightlyReleases<C>
+    where
+        F: FnMut(&RustRelease<Nightly, C>) -> Option<date::Date>,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let release_date = f(&r);
+                RustRelease {
+                    version: r.version,
+                    release_date,
+                    toolchains: r.toolchains,
+                    context: r.context,
+                }
+            })
+            .collect();
+
+        NightlyReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `toolchains` property of all releases in the set.
+    pub fn map_toolchains<F>(self, mut f: F) -> NightlyReleases<C>
+    where
+        F: FnMut(&RustRelease<Nightly, C>) -> Vec<toolchain::Toolchain>,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let toolchains = f(&r);
+                RustRelease {
+                    version: r.version,
+                    release_date: r.release_date,
+                    toolchains,
+                    context: r.context,
+                }
+            })
+            .collect();
+
+        NightlyReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `context` property of all releases in the set, changing the context type from `C` to `C2`.
+    pub fn map_context<C2, F>(self, mut f: F) -> NightlyReleases<C2>
+    where
+        F: FnMut(&RustRelease<Nightly, C>) -> C2,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let context = f(&r);
+                RustRelease {
+                    version: r.version,
+                    release_date: r.release_date,
+                    toolchains: r.toolchains,
+                    context,
+                }
+            })
+            .collect();
+
+        NightlyReleases(impls::ReleasesImpl::new(releases))
     }
 
     /// Merge two collections, applying `merge_fn` to releases that exist in both.
@@ -91,13 +216,7 @@ mod tests {
     use rust_release::date::Date;
 
     fn make_release(year: u16, month: u8, day: u8) -> RustRelease<Nightly> {
-        RustRelease::new(
-            Nightly {
-                date: Date::new(year, month, day),
-            },
-            None,
-            [],
-        )
+        RustRelease::new(Nightly::new(year, month, day), None, [])
     }
 
     #[test]
@@ -115,14 +234,23 @@ mod tests {
         assert_eq!(merged.len(), 3);
 
         let versions: Vec<_> = merged.iter().map(|r| &r.version).collect();
-        assert!(versions.contains(&&Nightly {
-            date: Date::new(2024, 1, 1)
-        }));
-        assert!(versions.contains(&&Nightly {
-            date: Date::new(2024, 1, 2)
-        }));
-        assert!(versions.contains(&&Nightly {
-            date: Date::new(2024, 1, 3)
-        }));
+        assert!(versions.contains(&&Nightly::new(2024, 1, 1)));
+        assert!(versions.contains(&&Nightly::new(2024, 1, 2)));
+        assert!(versions.contains(&&Nightly::new(2024, 1, 3)));
+    }
+
+    #[test]
+    fn map_version() {
+        let mut original = NightlyReleases::empty();
+        original.add(make_release(2024, 1, 2));
+        original.add(make_release(2024, 2, 3));
+        assert_eq!(original.len(), 2);
+
+        // Eq. is determined by version
+        let modified = original.map_version(|_n| Nightly::new(2024, 9, 9));
+        assert_eq!(modified.len(), 1);
+
+        let out = modified.iter().next().unwrap();
+        assert_eq!(out.version().date, Date::new(2024, 9, 9));
     }
 }

--- a/crates/rust-releases-core/src/releases/stable.rs
+++ b/crates/rust-releases-core/src/releases/stable.rs
@@ -1,6 +1,6 @@
 use crate::releases::impls;
 use crate::Stable;
-use rust_release::RustRelease;
+use rust_release::{date, toolchain, RustRelease};
 use std::fmt::Debug;
 use std::iter::FromIterator;
 
@@ -26,6 +26,131 @@ impl<C> StableReleases<C> {
     /// Iterate over the releases
     pub fn iter(&self) -> impl Iterator<Item = &RustRelease<Stable, C>> {
         self.0.iter()
+    }
+
+    /// Map the `release` and re-collect the result.
+    ///
+    /// # Warning: may result in unintended consequences
+    ///
+    /// Internally, versions are stored by `version` in a `BTreeSet`, so if you
+    /// map the version specifically, you might lose releases unexpectedly.
+    pub fn map<F>(self, f: F) -> StableReleases<C>
+    where
+        F: FnMut(RustRelease<Stable, C>) -> RustRelease<Stable, C>,
+    {
+        let releases = self.into_iter().map(f).collect();
+
+        StableReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `version` property of all releases in the set.
+    ///
+    /// # Warning: may result in unintended consequences
+    ///
+    /// Since the `version` field of a [`RustRelease`] is the only relevant property for
+    /// equivalence wrt `PartialEq`, `Eq`, `PartialOrd` and `Ord`, in set of `RustRelease` elements,
+    /// changing the `version` of multiple elements to the same version may have unintended
+    /// consequences.
+    ///
+    /// For example:
+    ///
+    /// ```
+    ///  # use rust_release::RustRelease;
+    ///  # use rust_releases_core::{Stable, StableReleases};
+    ///
+    ///  let item0 = RustRelease::new(Stable::new(1, 2, 3), None, []);
+    ///  let item1 = RustRelease::new(Stable::new(2, 3, 4), None, []);
+    ///
+    ///  let mut original = StableReleases::empty();
+    ///  original.add(item0.clone());
+    ///  original.add(item1.clone());
+    ///  assert_eq!(original.len(), 2);
+    ///
+    ///  // Eq. is determined by version
+    ///  let modified = original.map_version(|_| Stable::new(9, 9, 9));
+    ///  assert_eq!(modified.len(), 1);
+    /// ```
+    pub fn map_version<F>(self, mut f: F) -> StableReleases<C>
+    where
+        F: FnMut(&RustRelease<Stable, C>) -> Stable,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let version = f(&r);
+                RustRelease {
+                    version,
+                    release_date: r.release_date,
+                    toolchains: r.toolchains,
+                    context: r.context,
+                }
+            })
+            .collect();
+
+        StableReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `release_date` property of all releases in the set.
+    pub fn map_release_date<F>(self, mut f: F) -> StableReleases<C>
+    where
+        F: FnMut(&RustRelease<Stable, C>) -> Option<date::Date>,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let release_date = f(&r);
+                RustRelease {
+                    version: r.version,
+                    release_date,
+                    toolchains: r.toolchains,
+                    context: r.context,
+                }
+            })
+            .collect();
+
+        StableReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `toolchains` property of all releases in the set.
+    pub fn map_toolchains<F>(self, mut f: F) -> StableReleases<C>
+    where
+        F: FnMut(&RustRelease<Stable, C>) -> Vec<toolchain::Toolchain>,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let toolchains = f(&r);
+                RustRelease {
+                    version: r.version,
+                    release_date: r.release_date,
+                    toolchains,
+                    context: r.context,
+                }
+            })
+            .collect();
+
+        StableReleases(impls::ReleasesImpl::new(releases))
+    }
+
+    /// Map the `context` property of all releases in the set, changing the context type from `C` to `C2`.
+    pub fn map_context<C2, F>(self, mut f: F) -> StableReleases<C2>
+    where
+        F: FnMut(&RustRelease<Stable, C>) -> C2,
+    {
+        let releases = self
+            .into_iter()
+            .map(|r| {
+                let context = f(&r);
+                RustRelease {
+                    version: r.version,
+                    release_date: r.release_date,
+                    toolchains: r.toolchains,
+                    context,
+                }
+            })
+            .collect();
+
+        StableReleases(impls::ReleasesImpl::new(releases))
     }
 
     /// Merge two collections, applying `merge_fn` to releases that exist in both.
@@ -236,5 +361,23 @@ mod tests {
         let out = original.clone().into_iter().collect::<StableReleases<()>>();
 
         assert_eq!(original, out);
+    }
+
+    #[test]
+    fn map_version() {
+        let item0 = RustRelease::new(Stable::new(1, 2, 3), None, []);
+        let item1 = RustRelease::new(Stable::new(2, 3, 4), None, []);
+
+        let mut original = StableReleases::empty();
+        original.add(item0.clone());
+        original.add(item1.clone());
+        assert_eq!(original.len(), 2);
+
+        // Eq. is determined by version
+        let modified = original.map_version(|_s| Stable::new(9, 9, 9));
+        assert_eq!(modified.len(), 1);
+
+        let out = modified.iter().next().unwrap();
+        assert_eq!(out.version().version, RustVersion::new(9, 9, 9));
     }
 }

--- a/crates/rust-toolchain/CHANGELOG.md
+++ b/crates/rust-toolchain/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added `new` constructors for `Beta` and `Nightly`
+
 ## 2.0.0 - 2026-05-08
 
 ### Notice

--- a/crates/rust-toolchain/src/channel/beta.rs
+++ b/crates/rust-toolchain/src/channel/beta.rs
@@ -11,6 +11,16 @@ pub struct Beta {
     pub prerelease: Option<u32>,
 }
 
+impl Beta {
+    /// Instantiate a new `Beta` struct, representing the version of a release channel.
+    pub fn new(major: u64, minor: u64, patch: u64, prerelease: Option<u32>) -> Self {
+        Self {
+            version: RustVersion::new(major, minor, patch),
+            prerelease,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{channel::Beta, RustVersion};

--- a/crates/rust-toolchain/src/channel/nightly.rs
+++ b/crates/rust-toolchain/src/channel/nightly.rs
@@ -9,6 +9,15 @@ pub struct Nightly {
     pub date: Date,
 }
 
+impl Nightly {
+    /// Instantiate a new `Nightly` struct, representing the version of a release channel.
+    pub fn new(year: u16, month: u8, day: u8) -> Self {
+        Self {
+            date: Date::new(year, month, day),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{channel::Nightly, Date};


### PR DESCRIPTION
- Added `map`, `map_version`, `map_release_date`, `map_toolchains`, and `map_context` to `StableReleases`, `BetaReleases` and `NightlyReleases`
- Added new constructors to `Beta` and `Nightly`